### PR TITLE
Add Flask-based web API

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,50 @@
+# Bandage Web API
+
+This directory contains a simple Flask server exposing parts of the
+Bandage command line interface over HTTP.
+
+## Requirements
+
+- Python 3
+- [Flask](https://flask.palletsprojects.com/)
+- The `bandage` executable available in your `PATH`
+
+## Usage
+
+Start the server from this directory:
+
+```bash
+python server.py
+```
+
+The server listens on port `5000` by default.
+
+### `POST /load`
+Upload a graph file. Returns a JSON object with a session identifier.
+
+```bash
+curl -F file=@your_graph.gfa http://localhost:5000/load
+```
+
+Response example:
+
+```json
+{"session": "<id>"}
+```
+
+### `GET /image/<session>`
+Generate an image of the loaded graph using `bandage image`. The
+endpoint returns the generated PNG file.
+
+```bash
+curl -o graph.png http://localhost:5000/image/<id>
+```
+
+### `GET /info/<session>`
+Return statistics for the graph using `bandage info`.
+
+```bash
+curl http://localhost:5000/info/<id>
+```
+
+The response is plain text containing the output of `bandage info`.

--- a/web/server.py
+++ b/web/server.py
@@ -1,0 +1,61 @@
+from flask import Flask, request, send_file, abort, jsonify
+import tempfile
+import os
+import uuid
+import subprocess
+
+app = Flask(__name__)
+
+# In-memory mapping of session IDs to file paths
+SESSIONS = {}
+
+@app.route('/load', methods=['POST'])
+def load_graph():
+    if 'file' not in request.files:
+        return jsonify({'error': 'No file provided'}), 400
+    file = request.files['file']
+    if file.filename == '':
+        return jsonify({'error': 'Empty filename'}), 400
+
+    session_id = str(uuid.uuid4())
+    temp_dir = tempfile.mkdtemp(prefix='bandage_')
+    graph_path = os.path.join(temp_dir, file.filename)
+    file.save(graph_path)
+
+    SESSIONS[session_id] = graph_path
+    return jsonify({'session': session_id})
+
+
+def _get_graph(session_id):
+    path = SESSIONS.get(session_id)
+    if not path or not os.path.exists(path):
+        abort(404)
+    return path
+
+@app.route('/image/<session_id>')
+def image(session_id):
+    graph_path = _get_graph(session_id)
+    temp_dir = tempfile.mkdtemp(prefix='bandage_img_')
+    image_path = os.path.join(temp_dir, 'graph.png')
+    try:
+        subprocess.run([
+            'bandage', 'image', graph_path, image_path
+        ], check=True)
+    except subprocess.CalledProcessError as e:
+        return jsonify({'error': str(e)}), 500
+    return send_file(image_path, mimetype='image/png')
+
+@app.route('/info/<session_id>')
+def info(session_id):
+    graph_path = _get_graph(session_id)
+    try:
+        result = subprocess.run([
+            'bandage', 'info', graph_path
+        ], check=True, capture_output=True, text=True)
+    except subprocess.CalledProcessError as e:
+        return jsonify({'error': str(e)}), 500
+    return result.stdout, 200, {'Content-Type': 'text/plain; charset=utf-8'}
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)


### PR DESCRIPTION
## Summary
- add Flask server with endpoints for loading graphs and returning images/info
- document usage of the web API in a new README

## Testing
- `python -m py_compile web/server.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842523551cc83318a0f47143343277f