### PR TITLE
Add simple web viewer

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,27 @@
+# Web Graph Viewer
+
+This simple frontend displays graph data served by `server.py` using D3.js.
+
+## Running
+
+1. Start the server from the repository root:
+
+   ```bash
+   python server.py
+   ```
+
+   The server should expose an endpoint at `/graph` that returns JSON with
+   `nodes` and `links` arrays compatible with D3's force layout.
+
+2. In another terminal, serve the `web` directory (any static file server will
+   work). For example using Python:
+
+   ```bash
+   cd web
+   python -m http.server 8000
+   ```
+
+3. Open your browser to [http://localhost:8000](http://localhost:8000). The page
+   will fetch the graph data from `server.py` running on its default port and
+   render an interactive visualization supporting zoom, pan and
+   highlighting of nodes and edges on hover.

--- a/web/app.js
+++ b/web/app.js
@@ -1,0 +1,88 @@
+(async function() {
+    // fetch graph data from the server
+    const response = await fetch('/graph');
+    const data = await response.json();
+
+    const width = window.innerWidth;
+    const height = window.innerHeight;
+
+    const svg = d3.select('#graph')
+        .attr('viewBox', [0, 0, width, height])
+        .call(d3.zoom().on('zoom', ({transform}) => {
+            g.attr('transform', transform);
+        }));
+
+    const g = svg.append('g');
+
+    const link = g.append('g')
+        .attr('stroke', '#999')
+        .attr('stroke-opacity', 0.6)
+        .selectAll('line')
+        .data(data.links)
+        .enter().append('line')
+        .attr('class', 'link')
+        .attr('stroke-width', d => Math.sqrt(d.value));
+
+    const node = g.append('g')
+        .attr('stroke', '#fff')
+        .attr('stroke-width', 1.5)
+        .selectAll('circle')
+        .data(data.nodes)
+        .enter().append('circle')
+        .attr('class', 'node')
+        .attr('r', 5)
+        .attr('fill', '#69b3a2')
+        .call(drag(simulation));
+
+    node.append('title').text(d => d.id);
+
+    node.on('mouseover', function(event, d) {
+        d3.select(this).classed('highlight', true);
+        link.filter(l => l.source.id === d.id || l.target.id === d.id)
+            .classed('highlight', true);
+    }).on('mouseout', function(event, d) {
+        d3.select(this).classed('highlight', false);
+        link.classed('highlight', false);
+    });
+
+    const simulation = d3.forceSimulation(data.nodes)
+        .force('link', d3.forceLink(data.links).id(d => d.id))
+        .force('charge', d3.forceManyBody())
+        .force('center', d3.forceCenter(width / 2, height / 2));
+
+    simulation.on('tick', () => {
+        link
+            .attr('x1', d => d.source.x)
+            .attr('y1', d => d.source.y)
+            .attr('x2', d => d.target.x)
+            .attr('y2', d => d.target.y);
+
+        node
+            .attr('cx', d => d.x)
+            .attr('cy', d => d.y);
+    });
+
+    function drag(sim) {
+        function dragstarted(event) {
+            if (!event.active) sim.alphaTarget(0.3).restart();
+            event.subject.fx = event.subject.x;
+            event.subject.fy = event.subject.y;
+        }
+
+        function dragged(event) {
+            event.subject.fx = event.x;
+            event.subject.fy = event.y;
+        }
+
+        function dragended(event) {
+            if (!event.active) sim.alphaTarget(0);
+            event.subject.fx = null;
+            event.subject.fy = null;
+        }
+
+        return d3.drag()
+            .on('start', dragstarted)
+            .on('drag', dragged)
+            .on('end', dragended);
+    }
+})();

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Graph Viewer</title>
+    <style>
+        body { margin: 0; font-family: Arial, sans-serif; }
+        svg { width: 100vw; height: 100vh; display: block; }
+        .link { stroke: #999; stroke-opacity: 0.6; }
+        .node circle { stroke: #fff; stroke-width: 1.5px; }
+        .highlight { stroke: #f00 !important; fill: #f00 !important; }
+    </style>
+</head>
+<body>
+    <svg id="graph"></svg>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.5/d3.min.js"></script>
+    <script src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a simple D3-based viewer in `web/`
- document how to serve the frontend alongside `server.py`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68425291165883318978494eaec1e155